### PR TITLE
fix(highlights): Fix support for Multibyte characters

### DIFF
--- a/lua/cmdline-hl/highlighters.lua
+++ b/lua/cmdline-hl/highlighters.lua
@@ -46,8 +46,9 @@ function M.ts(str, language, default_hl)
     -- this is needed otherwise comments don't get parsed properly
     str = str .. "\n"
     local ret = {}
-    for i = 1, #str, 1 do
-        ret[i] = { str:sub(i, i), default_hl }
+    local len = vim.fn.strchars(str)
+    for i = 0, len - 1 do
+        ret[i + 1] = { vim.fn.strcharpart(str, i, 1), default_hl }
     end
     local priority_list = {}
     local parent_tree = ts.get_string_parser(str, language)
@@ -81,6 +82,7 @@ function M.ts(str, language, default_hl)
             local priority = 100 + (metadata.priority or 0)
             for i = start_col, end_col - 1, 1 do
                 if (priority_list[i + 1] or 0) <= priority then
+                    if ret[i + 1] == nil then vim.print(ret,i+1,end_col) end
                     ret[i + 1][2] = hl
                     priority_list[i + 1] = priority
                 end

--- a/lua/cmdline-hl/highlighters.lua
+++ b/lua/cmdline-hl/highlighters.lua
@@ -79,10 +79,10 @@ function M.ts(str, language, default_hl)
             if end_col == 0 then
                 end_col = #str
             end
+            local char_end_col = vim.str_utfindex(str,end_col)
             local priority = 100 + (metadata.priority or 0)
-            for i = start_col, end_col - 1, 1 do
+            for i = start_col, char_end_col - 1, 1 do
                 if (priority_list[i + 1] or 0) <= priority then
-                    if ret[i + 1] == nil then vim.print(ret,i+1,end_col) end
                     ret[i + 1][2] = hl
                     priority_list[i + 1] = priority
                 end


### PR DESCRIPTION
Trying to fix support for multibyte characters (utf8) as they don't get printed correctly.
Having trouble with `nil` indexing inside the `ts()` function

![image](https://github.com/Sam-programs/cmdline-hl.nvim/assets/61395246/dbecc5a2-e5e6-4f0a-8a2f-dc667e701875)
