### PR TITLE
fix to the cursor pos bug where too small value can cause nil exception

### DIFF
--- a/lua/cmdline-hl/highlighters.lua
+++ b/lua/cmdline-hl/highlighters.lua
@@ -25,7 +25,7 @@ function M.cmdline(cmdinfo, cmdline, col)
             retval = utils.tbl_merge(range_tbl, cmd_tbl, retval)
         else
             if col ~= -1 then
-                if col < #range + cmd_len then
+                if col <= range + cmd_len then
                     local cmd_tbl = M.ts(cmd:sub(1, cmd_len), "vim")
                     local range_tbl = utils.str_to_tbl(range, config.range_hl)
                     retval = utils.tbl_merge(range_tbl, cmd_tbl)
@@ -64,7 +64,9 @@ function M.ts(str, language, default_hl)
             end
         end
         local query = hl_cache[lang]
-        for id, node, metadata in query:iter_captures(tstree:root(), str, 0, 1, {}) do
+        for id, node, metadata in
+            query:iter_captures(tstree:root(), str, 0, 1, {})
+        do
             -- `node` was captured by the `name` capture in the match
             local hl = "@" .. query.captures[id]
             if hl:find("_") then
@@ -89,7 +91,7 @@ function M.ts(str, language, default_hl)
         end
     end)
     -- remove \n
-    ret[#ret] = nil;
+    ret[#ret] = nil
     return ret
 end
 

--- a/lua/cmdline-hl/init.lua
+++ b/lua/cmdline-hl/init.lua
@@ -66,7 +66,7 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
             end
         end
     end
-    if render_cursor < #hl_cmdline then
+    if render_cursor <= #hl_cmdline then
         local cur_hl = vim.api.nvim_get_hl(
             0,
             { name = hl_cmdline[render_cursor][2], link = false }

--- a/lua/cmdline-hl/init.lua
+++ b/lua/cmdline-hl/init.lua
@@ -22,21 +22,22 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
     local render_cursor = cursor
     if prefix == ":" then
         local ok, cmdinfo = pcall(vim.api.nvim_parse_cmd, cmdline, {})
-        if (not ok) then
+        if not ok then
             cmdinfo = { cmd = "?" }
         end
         local render_cmdline
-        render_cmdline,render_cursor = alias.cmdline(cmdinfo, cmdline,cursor)
-        hl_cmdline, render_cursor, ctype = highlighters.cmdline(cmdinfo, render_cmdline, render_cursor)
+        render_cmdline, render_cursor = alias.cmdline(cmdinfo, cmdline, cursor)
+        hl_cmdline, render_cursor, ctype =
+            highlighters.cmdline(cmdinfo, render_cmdline, render_cursor)
     end
     if utils.issearch(prefix) then
         hl_cmdline = highlighters.ts(cmdline, "regex")
     end
     if prefix == "=" then
         local expr_start = "let a="
-        hl_cmdline = highlighters.ts(expr_start .. cmdline,"vim")
-        for _ = 1,#expr_start,1 do
-            table.remove(hl_cmdline,1)
+        hl_cmdline = highlighters.ts(expr_start .. cmdline, "vim")
+        for _ = 1, #expr_start, 1 do
+            table.remove(hl_cmdline, 1)
         end
     end
 
@@ -50,9 +51,7 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
         goto theend
     end
     if M.config.ghost_text then
-        if
-            ((#hl_cmdline + 1) == render_cursor or M.config.inline_ghost_text)
-        then
+        if (#hl_cmdline + 1) == render_cursor or M.config.inline_ghost_text then
             local ghost_text = M.config.ghost_text_provider(
                 prefix,
                 cmdline,
@@ -67,7 +66,7 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
             end
         end
     end
-    if render_cursor <= #hl_cmdline then
+    if render_cursor < #hl_cmdline then
         local cur_hl = vim.api.nvim_get_hl(
             0,
             { name = hl_cmdline[render_cursor][2], link = false }
@@ -125,17 +124,21 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
         if M.config.type_signs[prefix] then
             table.insert(hl_cmdline, 1, M.config.type_signs[prefix])
         else
-            table.insert(hl_cmdline, 1, { M.config.input_format(prefix), M.config.input_hl })
+            table.insert(
+                hl_cmdline,
+                1,
+                { M.config.input_format(prefix), M.config.input_hl }
+            )
         end
     end
-    local len     = 0
+    local len = 0
     -- the prefix doesn't follow the 1 item 1 character style so this is needed
-    len           = len + #hl_cmdline[1][1]
-    len           = len + #hl_cmdline - 1
+    len = len + #hl_cmdline[1][1]
+    len = len + #hl_cmdline - 1
     local last_ch = vim.o.ch
-    local new_ch  = math.ceil((len + 1) / vim.o.columns)
-    if (last_ch ~= new_ch) then
-        if (ch_before == -1) then
+    local new_ch = math.ceil((len + 1) / vim.o.columns)
+    if last_ch ~= new_ch then
+        if ch_before == -1 then
             ch_before = last_ch
         end
         vim.o.ch = new_ch
@@ -150,8 +153,6 @@ end
 local draw_lastcmdline = function()
     draw_cmdline(last_ctx.prefix, last_ctx.cmdline, last_ctx.cursor)
 end
-
-
 
 -- resizing clears messages
 vim.api.nvim_create_autocmd("VimResized", {
@@ -229,22 +230,22 @@ M.setup = function(opts)
         ui_attached = true
         vim.ui_attach(cmdline_ns, { ext_cmdline = true }, function(name, ...)
             if handler[name] then
-                xpcall(handler[name],
-                    function(msg)
-                        if msg == nil then
-                            return
-                        end
-                        local backtrace = debug.traceback(msg, 1)
-                        vim.schedule(
-                            function()
-                                vim.notify(
-                                    'cmdline-hl.nvim: Disabling cmdline highlighting please open an issue with this backtrace, you can copy it with lmouse:\n' ..
-                                    backtrace,
-                                    vim.log.levels.ERROR, {})
-                                vim.api.nvim_input('<esc>:messages<cr>')
-                                M.disable()
-                            end)
-                    end,...)
+                xpcall(handler[name], function(msg)
+                    if msg == nil then
+                        return
+                    end
+                    local backtrace = debug.traceback(msg, 1)
+                    vim.schedule(function()
+                        vim.notify(
+                            "cmdline-hl.nvim: Disabling cmdline highlighting please open an issue with this backtrace, you can copy it with lmouse:\n"
+                                .. backtrace,
+                            vim.log.levels.ERROR,
+                            {}
+                        )
+                        vim.api.nvim_input("<esc>:messages<cr>")
+                        M.disable()
+                    end)
+                end, ...)
             end
         end)
     end


### PR DESCRIPTION
## Fix: fix to the cursor pos bug where too small value can cause nil exception

**Issue recording:** 

https://github.com/user-attachments/assets/b4a6c1bb-1161-4339-93a3-221437a4622f


**Issue Number:** None. Fixing in place

### Description and fix implementation

If cursor is being backtracked to the beginning of cmdline with the substitute icon displayed it can result in attempt to read nil tripping an execution flow, breaking and disabling plugin entirely. All is need is a small change from check in cursor rendering function from less than or equal to less than condition.


### Changes Made

In main plugin's `init.lua:69` (noice)
From:
```lua
    if render_cursor <= #hl_cmdline then
```
To:
```lua
    if render_cursor < #hl_cmdline then
```

### Testing

Manual. Not considered necessary for such small tweak.


---

Thanks for reviewing this pull request! Small as it is, it fixes a major annoyance I had ;)
