### PR TITLE
fix: Clear error message when treesitter parser is not avalable.

### DIFF
--- a/lua/cmdline-hl/highlighters.lua
+++ b/lua/cmdline-hl/highlighters.lua
@@ -50,7 +50,18 @@ function M.ts(str, language, default_hl)
         ret[i] = { str:sub(i, i), default_hl }
     end
     local priority_list = {}
-    local parent_tree = ts.get_string_parser(str, language)
+    local parent_tree_success, parent_tree =
+        pcall(ts.get_string_parser, str, language)
+    if not parent_tree_success then
+        vim.notify(
+            "Treesitter parser not installed for `"
+                .. language
+                .. "`, cannot continue. \n\n",
+            vim.log.levels.ERROR
+        )
+        error(parent_tree)
+    end
+
     parent_tree:parse(true)
     parent_tree:for_each_tree(function(tstree, tree)
         if not tstree then
@@ -64,7 +75,9 @@ function M.ts(str, language, default_hl)
             end
         end
         local query = hl_cache[lang]
-        for id, node, metadata in query:iter_captures(tstree:root(), str, 0, 1, {}) do
+        for id, node, metadata in
+            query:iter_captures(tstree:root(), str, 0, 1, {})
+        do
             -- `node` was captured by the `name` capture in the match
             local hl = "@" .. query.captures[id]
             if hl:find("_") then
@@ -89,7 +102,7 @@ function M.ts(str, language, default_hl)
         end
     end)
     -- remove \n
-    ret[#ret] = nil;
+    ret[#ret] = nil
     return ret
 end
 

--- a/lua/cmdline-hl/highlighters.lua
+++ b/lua/cmdline-hl/highlighters.lua
@@ -54,7 +54,7 @@ function M.ts(str, language, default_hl)
         pcall(ts.get_string_parser, str, language)
     if not parent_tree_success then
         vim.notify(
-            "Treesitter parser not installed for `"
+            "cmdline-hl.nvim: Missing treesitter parser for `"
                 .. language
                 .. "`, cannot continue. \n\n",
             vim.log.levels.ERROR

--- a/lua/cmdline-hl/init.lua
+++ b/lua/cmdline-hl/init.lua
@@ -26,7 +26,7 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
             cmdinfo = { cmd = "?" }
         end
         local render_cmdline
-        render_cmdline,render_cursor = alias.cmdline(cmdinfo, cmdline,cursor)
+        render_cmdline, render_cursor = alias.cmdline(cmdinfo, cmdline, cursor)
         hl_cmdline, render_cursor, ctype = highlighters.cmdline(cmdinfo, render_cmdline, render_cursor)
     end
     if utils.issearch(prefix) then
@@ -34,9 +34,9 @@ local draw_cmdline = function(prefix, cmdline, cursor, force)
     end
     if prefix == "=" then
         local expr_start = "let a="
-        hl_cmdline = highlighters.ts(expr_start .. cmdline,"vim")
-        for _ = 1,#expr_start,1 do
-            table.remove(hl_cmdline,1)
+        hl_cmdline = highlighters.ts(expr_start .. cmdline, "vim")
+        for _ = 1, #expr_start, 1 do
+            table.remove(hl_cmdline, 1)
         end
     end
 
@@ -223,6 +223,17 @@ local ui_attached = false
 M.setup = function(opts)
     config.set(opts)
     if not ui_attached then
+
+        local parent_tree_success =
+            pcall(vim.treesitter.get_string_parser, "", "regex")
+        if not parent_tree_success then
+            vim.notify(
+                "\n\ncmdline-hl.nvim: Missing treesitter parser for `regex` \n",
+                vim.log.levels.ERROR
+            )
+            error()
+        end
+
         -- we render our own cursor
         vim.api.nvim_set_hl(0, "HIDDEN", { blend = 100, nocombine = true })
         vim.opt_global.guicursor:append({ "ci:HIDDEN", "c:HIDDEN", "cr:HIDDEN" })
@@ -244,7 +255,7 @@ M.setup = function(opts)
                                 vim.api.nvim_input('<esc>:messages<cr>')
                                 M.disable()
                             end)
-                    end,...)
+                    end, ...)
             end
         end)
     end


### PR DESCRIPTION
Added a clearer error message for when treesitter parser is not installed. I found it to be not so clear what to do when i didn't have the `regex` parser installed and got a long error message.